### PR TITLE
Fixed launchSettings, UseCors and HttpClient uri

### DIFF
--- a/dotnetflix.Api/Program.cs
+++ b/dotnetflix.Api/Program.cs
@@ -3,6 +3,7 @@ using dotnetflix.Api.Repositories.Movies;
 using dotnetflix.Api.Repositories.Shows;
 using dotnetflix.Api.Repositories.Theaters;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Net.Http.Headers;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -29,13 +30,11 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
-/*
 app.UseCors(policy =>
-    policy.WithOrigins("http://localhost:7019", "https://localhost:7019")
+    policy.WithOrigins("http://localhost:5194", "https://localhost:7019")
         .AllowAnyMethod()
         .WithHeaders(HeaderNames.ContentType)
 );
-*/
 
 app.UseHttpsRedirection();
 

--- a/dotnetflix.Api/Program.cs
+++ b/dotnetflix.Api/Program.cs
@@ -29,6 +29,14 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
+/*
+app.UseCors(policy =>
+    policy.WithOrigins("http://localhost:7019", "https://localhost:7019")
+        .AllowAnyMethod()
+        .WithHeaders(HeaderNames.ContentType)
+);
+*/
+
 app.UseHttpsRedirection();
 
 app.UseAuthorization();

--- a/dotnetflix.Api/Program.cs
+++ b/dotnetflix.Api/Program.cs
@@ -32,7 +32,7 @@ if (app.Environment.IsDevelopment())
 
 
 app.UseCors(policy =>
-    policy.WithOrigins("http://localhost:7257", "https://localhost:7257")
+    policy.WithOrigins("http://localhost:5106", "https://localhost:7257")
         .AllowAnyMethod()
         .WithHeaders(HeaderNames.ContentType)
 );

--- a/dotnetflix.Api/Program.cs
+++ b/dotnetflix.Api/Program.cs
@@ -3,6 +3,7 @@ using dotnetflix.Api.Repositories.Movies;
 using dotnetflix.Api.Repositories.Shows;
 using dotnetflix.Api.Repositories.Theaters;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Net.Http.Headers;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -29,13 +30,12 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
-/*
+
 app.UseCors(policy =>
-    policy.WithOrigins("http://localhost:7019", "https://localhost:7019")
+    policy.WithOrigins("http://localhost:7257", "https://localhost:7257")
         .AllowAnyMethod()
         .WithHeaders(HeaderNames.ContentType)
 );
-*/
 
 app.UseHttpsRedirection();
 

--- a/dotnetflix.Api/Properties/launchSettings.json
+++ b/dotnetflix.Api/Properties/launchSettings.json
@@ -4,8 +4,8 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:56815",
-      "sslPort": 44373
+      "applicationUrl": "http://localhost:30814",
+      "sslPort": 44336
     }
   },
   "profiles": {
@@ -14,7 +14,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "http://localhost:5247",
+      "applicationUrl": "http://localhost:5165",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -24,7 +24,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:7000;http://localhost:5247",
+      "applicationUrl": "https://localhost:7100;http://localhost:5165",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/dotnetflix.Web/Pages/Home.razor
+++ b/dotnetflix.Web/Pages/Home.razor
@@ -1,4 +1,4 @@
-﻿@page "/"
+﻿@page "/Home"
 
 <PageTitle>Home</PageTitle>
 

--- a/dotnetflix.Web/Pages/Home.razor
+++ b/dotnetflix.Web/Pages/Home.razor
@@ -1,7 +1,0 @@
-﻿@page "/Home"
-
-<PageTitle>Home</PageTitle>
-
-<h1>Hello, world!</h1>
-
-Welcome to your new app.

--- a/dotnetflix.Web/Pages/HomePage.razor
+++ b/dotnetflix.Web/Pages/HomePage.razor
@@ -10,9 +10,6 @@
 
     if (showCount > 0)
     {
-        // var shows = new List<ShowDto>();
-        // var shows = Shows.ToList();
-
         @foreach (var show in Shows)
         {
             <ul>

--- a/dotnetflix.Web/Pages/HomePage.razor
+++ b/dotnetflix.Web/Pages/HomePage.razor
@@ -1,0 +1,50 @@
+@page "/"
+@using dotnetflix.Web.Services.Contracts
+@using dotnetflix.Models.Dtos.Show
+
+<h3>Nu in de bioscoop</h3>
+
+<p>Found shows: @Shows.Count()</p>
+
+@* @if (Shows.Any()) *@
+@* { *@
+@*     var showCount = Shows.Count(); *@
+@* *@
+@*     if (showCount > 0) *@
+@*     { *@
+@*         // var shows = new List<ShowDto>(); *@
+@*         // var shows = Shows.ToList(); *@
+@* *@
+@*         @foreach (var show in Shows) *@
+@*         { *@
+@*             <ul> *@
+@*                 <li>@show.MovieTitle</li> *@
+@*                 <li>@show.Date</li> *@
+@*             </ul> *@
+@*         } *@
+@*     } *@
+@*     else *@
+@*     { *@
+@*         <h3>Geen films gevonden</h3> *@
+@*     } *@
+@* } *@
+@* else *@
+@* { *@
+@*     <h3>Loading</h3> *@
+@* } *@
+
+@code {
+    // 1) Set properties te facilitate dependency injection
+    // 2) Public properties to expose to the view
+    // 3) Method to be called when the component is initialized
+
+    [Inject] public IShowService ShowService { get; set; }
+
+    public IEnumerable<ShowDto> Shows { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        Shows = await ShowService.GetShows();
+    }
+
+}

--- a/dotnetflix.Web/Pages/HomePage.razor
+++ b/dotnetflix.Web/Pages/HomePage.razor
@@ -4,47 +4,49 @@
 
 <h3>Nu in de bioscoop</h3>
 
-<p>Found shows: @Shows.Count()</p>
+@if (Shows != null)
+{
+    var showCount = Shows.Count();
 
-@* @if (Shows.Any()) *@
-@* { *@
-@*     var showCount = Shows.Count(); *@
-@* *@
-@*     if (showCount > 0) *@
-@*     { *@
-@*         // var shows = new List<ShowDto>(); *@
-@*         // var shows = Shows.ToList(); *@
-@* *@
-@*         @foreach (var show in Shows) *@
-@*         { *@
-@*             <ul> *@
-@*                 <li>@show.MovieTitle</li> *@
-@*                 <li>@show.Date</li> *@
-@*             </ul> *@
-@*         } *@
-@*     } *@
-@*     else *@
-@*     { *@
-@*         <h3>Geen films gevonden</h3> *@
-@*     } *@
-@* } *@
-@* else *@
-@* { *@
-@*     <h3>Loading</h3> *@
-@* } *@
+    if (showCount > 0)
+    {
+        // var shows = new List<ShowDto>();
+        // var shows = Shows.ToList();
+
+        @foreach (var show in Shows)
+        {
+            <ul>
+                <li>@show.MovieTitle</li>
+                <li>@show.Date</li>
+            </ul>
+        }
+    }
+    else
+    {
+        <h3>Geen films gevonden</h3>
+    }
+}
+else
+{
+    <h3>Loading</h3>
+}
 
 @code {
     // 1) Set properties te facilitate dependency injection
     // 2) Public properties to expose to the view
     // 3) Method to be called when the component is initialized
 
-    [Inject] public IShowService ShowService { get; set; }
+    [Inject] public IShowService? ShowService { get; set; }
 
-    public IEnumerable<ShowDto> Shows { get; set; }
+    public IEnumerable<ShowDto>? Shows { get; set; }
 
     protected override async Task OnInitializedAsync()
     {
-        Shows = await ShowService.GetShows();
+        if (ShowService != null)
+        {
+            Shows = await ShowService.GetShows();
+        }
     }
+
 
 }

--- a/dotnetflix.Web/Program.cs
+++ b/dotnetflix.Web/Program.cs
@@ -1,4 +1,6 @@
 using dotnetflix.Web;
+using dotnetflix.Web.Services;
+using dotnetflix.Web.Services.Contracts;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 
@@ -7,5 +9,10 @@ builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+// builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri("http://localhost:7000/") });
+
+// Register services
+builder.Services.AddScoped<IMovieService, MovieService>();
+builder.Services.AddScoped<IShowService, ShowService>();
 
 await builder.Build().RunAsync();

--- a/dotnetflix.Web/Program.cs
+++ b/dotnetflix.Web/Program.cs
@@ -8,7 +8,7 @@ var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
-builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri("https://localhost:7100/") });
 // builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri("http://localhost:7000/") });
 
 // Register services

--- a/dotnetflix.Web/Program.cs
+++ b/dotnetflix.Web/Program.cs
@@ -9,7 +9,6 @@ builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri("https://localhost:7100/") });
-// builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri("http://localhost:7000/") });
 
 // Register services
 builder.Services.AddScoped<IMovieService, MovieService>();

--- a/dotnetflix.Web/Program.cs
+++ b/dotnetflix.Web/Program.cs
@@ -8,8 +8,8 @@ var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
-builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
-// builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri("http://localhost:7000/") });
+// builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri("http://localhost:5247/") });
 
 // Register services
 builder.Services.AddScoped<IMovieService, MovieService>();

--- a/dotnetflix.Web/Properties/launchSettings.json
+++ b/dotnetflix.Web/Properties/launchSettings.json
@@ -4,8 +4,8 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:20194",
-      "sslPort": 44303
+      "applicationUrl": "http://localhost:21815",
+      "sslPort": 44395
     }
   },
   "profiles": {
@@ -14,7 +14,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
-      "applicationUrl": "http://localhost:5194",
+      "applicationUrl": "http://localhost:5106",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -24,7 +24,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
-      "applicationUrl": "https://localhost:7019;http://localhost:5194",
+      "applicationUrl": "https://localhost:7257;http://localhost:5106",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
- Use API in https (defaults now to 7100)
- Use Web in http for Hot reload (talks to API via 5106)
- Optional use Web https (talks to API via 7257)