### PR TITLE
US24 Add links to Social media

### DIFF
--- a/dotnetflix.Web/Layout/Header.razor
+++ b/dotnetflix.Web/Layout/Header.razor
@@ -1,0 +1,28 @@
+@* <FluentDivider Style="width: 100%;"></FluentDivider> *@
+<FluentGrid Justify="JustifyContent.FlexEnd">
+    <FluentGridItem>
+        <p class="pt-1">Follow us on social:</p>
+    </FluentGridItem>
+    <FluentGridItem Justify="JustifyContent.FlexEnd" Gap="10px">
+        <FluentAnchor Href="https://www.instagram.com/pathenederland/" Target="_blank">
+            <i class="bi bi-instagram"></i>
+        </FluentAnchor>
+        <FluentAnchor Href="https://www.facebook.com/pathenederland" Target="_blank">
+            <i class="bi bi-facebook"></i>
+        </FluentAnchor>
+        <FluentAnchor Href="@_urlTiktok" Target="_blank">
+            <i class="bi bi-tiktok"></i>
+        </FluentAnchor>
+        <FluentAnchor Href="@_urlPathe" Target="_blank">
+            <i class="bi bi-youtube"></i>
+        </FluentAnchor>
+        <FluentAnchor Href="https://twitter.com/Pathenederland" Target="_blank">
+            <i class="bi bi-twitter-x"></i>
+        </FluentAnchor>
+    </FluentGridItem>
+</FluentGrid>
+
+@code {
+    private string _urlTiktok = "https://www.tiktok.com/@pathenederland";
+    private string _urlPathe = "https://www.youtube.com/@pathenederland";
+}

--- a/dotnetflix.Web/Layout/MainLayout.razor
+++ b/dotnetflix.Web/Layout/MainLayout.razor
@@ -1,21 +1,19 @@
 ﻿@inherits LayoutComponentBase
 <div class="page">
     <div class="sidebar">
-        <NavMenu />
+        <NavMenu/>
     </div>
-
     <main>
-        @* <div class="top-row px-4"> *@
-        @*     <a href="https://learn.microsoft.com/aspnet/core/" target="_blank">About</a> *@
-        @* </div> *@
-
+        <div class="top-row px-4 pt-3 pb-1">
+            <Header></Header>
+        </div>
         <article class="content px-4">
             @Body
         </article>
     </main>
 </div>
 
-<FluentToastProvider />
-<FluentDialogProvider />
-<FluentTooltipProvider />
-<FluentMessageBarProvider />
+<FluentToastProvider/>
+<FluentDialogProvider/>
+<FluentTooltipProvider/>
+<FluentMessageBarProvider/>


### PR DESCRIPTION
This PR is a cheap solution to have social media links into the .NETflix app.
This header will change in the upcomming Fluent UI update that I'm currently working on.
For the review of Sprint 2 this will have to do. Meet the Definition of done of US24: Koppelingen naar social media.

<img width="515" alt="Screenshot 2024-03-12 at 11 26 47" src="https://github.com/Digital-Architects-Avans/dotnetflix/assets/8493108/ba8db4dd-36fc-4f6c-9b8d-67d59c9eee87">